### PR TITLE
Automated konflux updates management

### DIFF
--- a/.tekton/yarn3-nodejs20-ubi9-minimal-push.yaml
+++ b/.tekton/yarn3-nodejs20-ubi9-minimal-push.yaml
@@ -8,8 +8,7 @@ metadata:
     pipelinesascode.tekton.dev/cancel-in-progress: "false"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
-      == "main" && ( "yarn3-nodejs20-ubi9-minimal/***".pathChanged() || ".tekton/yarn3-nodejs20-ubi9-minimal-push.yaml".pathChanged()
-      || "Containerfile".pathChanged() )
+      == "main" && ( "yarn3-nodejs20-ubi9-minimal/***".pathChanged() || "Containerfile".pathChanged() )
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: yarn-builder

--- a/.tekton/yarn4-nodejs22-ubi9-minimal-push.yaml
+++ b/.tekton/yarn4-nodejs22-ubi9-minimal-push.yaml
@@ -8,8 +8,7 @@ metadata:
     pipelinesascode.tekton.dev/cancel-in-progress: "false"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
-      == "main" && ( "yarn4-nodejs22-ubi9-minimal/***".pathChanged() || ".tekton/yarn4-nodejs22-ubi9-minimal-push.yaml".pathChanged()
-      || "Containerfile".pathChanged() )
+      == "main" && ( "yarn4-nodejs22-ubi9-minimal/***".pathChanged() || "Containerfile".pathChanged() )
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: yarn-builder

--- a/renovate.json
+++ b/renovate.json
@@ -15,5 +15,8 @@
             ],
             "versioningTemplate": "docker"
         }
-    ]
+    ],
+    "tekton": {
+        "automerge": true
+    }
 }


### PR DESCRIPTION
The intent here is to automate tekton pipeline management and reduce spam to consumers at the same time.

The weekly konflux references updates on saturdays will be tested and the changes will be automerged when the CI is green, however, we will not rebuild the container with just those changes. This way we will reduce the spam to downstream consumers of these images since there are no substantial changes to the container image itself